### PR TITLE
fixed var references when VarOpen or VarClose are not exactly 2 chars

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -61,7 +61,7 @@ func (c *Ini) parseVarReference(key, valStr string, sec Section) string {
 	var oldNew []string
 	for _, fVar := range vars {
 		realVal := fVar
-		name = fVar[2 : len(fVar)-2]
+		name = fVar[len(c.opts.VarOpen) : len(fVar)-len(c.opts.VarClose)]
 
 		if val, ok := sec[name]; ok && key != name {
 			realVal = val

--- a/parse.go
+++ b/parse.go
@@ -56,12 +56,15 @@ func (c *Ini) parseVarReference(key, valStr string, sec Section) string {
 	if len(vars) == 0 {
 		return valStr
 	}
+	
+	varOLen := len(c.opts.VarOpen)
+	varCLen := len(c.opts.VarClose)
 
 	var name string
 	var oldNew []string
 	for _, fVar := range vars {
 		realVal := fVar
-		name = fVar[len(c.opts.VarOpen) : len(fVar)-len(c.opts.VarClose)]
+		name = fVar[varOLen : len(fVar)-varCLen]
 
 		if val, ok := sec[name]; ok && key != name {
 			realVal = val


### PR DESCRIPTION
I load some ini files that have a specific format for var reference : ${Section|Key}
The parser assumes 2 characters for VarOpen and VarClose, so this does not work.
This PR uses the length of VarOpen and VarClose options to get the name of the section/key
